### PR TITLE
Update config.ts to use Amoy

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 export const networkConfig = {
   testnet: {
-    URL: 'https://rpc-mumbai.maticvigil.com/',
-    CONTRACT_ADDRESS: '0x8B335A167DA81CCef19C53eE629cf2F6291F2255',
+    URL: 'https://rpc-amoy.polygon.technology/',
+    CONTRACT_ADDRESS: '0x3D98a2f7dFdAB3c09A28e95f5e49f26be87f7f95',
   },
   mainnet: {
     URL: 'https://polygon-rpc.com',


### PR DESCRIPTION
The config is outdated and it's causing testnet contract call to fail. A new PolygonDidRegistry is deployed on Amoy testnet https://amoy.polygonscan.com/address/0x3D98a2f7dFdAB3c09A28e95f5e49f26be87f7f95 and the configuration is updated to use Amoy instead of mumbai